### PR TITLE
Interstitial ads black screen issue

### DIFF
--- a/sources/engine/Xenko.Engine/Starter/iOSXenkoView.cs
+++ b/sources/engine/Xenko.Engine/Starter/iOSXenkoView.cs
@@ -100,6 +100,12 @@ namespace Xenko.Starter
 
             isRunning = false;
         }
+        
+        public override void WillMoveToWindow(UIWindow window)
+        {
+            if (window != null)
+                base.WillMoveToWindow (window);
+        }
 
         [Export("drawFrame")]
         void DrawFrame()


### PR DESCRIPTION
When implementing full page or interstitial ads such as google admob a black screen appears on any iOS device after the ad is loaded. This is a known problem with OpenTK-1.1 and the solution is to override WillMoveToWindow in iPhoneOSGameView so as to not suspend the window which causes the problem.
I had this patched back in version 1.10.2 beta throught a custom patch by Virgile. Should help those who are interested in showing full page ads in your games.